### PR TITLE
Change to wake_up command

### DIFF
--- a/Tesla/Tesla.psm1
+++ b/Tesla/Tesla.psm1
@@ -1955,10 +1955,19 @@ function Invoke-TeslaVehicleWakeUp {
     } #BEGIN
 
     PROCESS {
+        
+        if ($Token.psobject.Properties.Name -contains "access_token") {
+            $Token = $Token.access_token
+        }
+    
+        $Headers =  @{
+            "Authorization" = "Bearer $Token"
+            "Accept-Encoding" = "gzip,deflate"
+        }
 
-        Write-Verbose "Executing 'wake_up'"
-        Invoke-TeslaVehicleCommand -Vehicle $Vehicle -Token $Token -Command wake_up
-          
+        Write-Verbose "Executing wake_up"
+        $TeslaCommand = Invoke-RestMethod -Uri "$ApiUri/vehicles/$($Vehicle.Id)/wake_up" -Method Post -Headers $Headers -ContentType 'application/json'| Select-Object -ExpandProperty Response
+                
     } #PROCESS
 
     END {


### PR DESCRIPTION
API changes ask for the wake_up command to be sent using a different URI from the rest of the commands. Current code makes POST to 
"/command/wake_up". https://tesla-api.timdorr.com/vehicle/commands/wake